### PR TITLE
support download from ftp

### DIFF
--- a/modis_atm/download.py
+++ b/modis_atm/download.py
@@ -1,34 +1,106 @@
+import os
+import shutil
+import posixpath
 import logging
 
-from earthdata_download import download as eddownload
+import ftputil
+import ftputil.error
+import requests
+
+try:
+    from urllib.parse import urlparse
+except ImportError:
+    # Python 2
+    from urlparse import urlparse
 
 logger = logging.getLogger(__name__)
 
 EXTENSIONS = ['.hdf', '.zip', '.nc4', '.nc']
+SCHEMES = ['https', 'ftp']
 
 
-def _get_https_data_url(urls, extensions=EXTENSIONS):
+def _get_data_url(urls, extensions=EXTENSIONS):
     """Find URL that starts with https and ends with a data file extension"""
+    urls_schemes = {}
     for url in urls:
-        url_lower = url.lower()
-        if url_lower.startswith('https'):
-            for ext in extensions:
-                if url_lower.endswith(ext):
-                    return url
+        o = urlparse(url)
+        if o.scheme in SCHEMES:
+            if posixpath.splitext(o.path)[1] in EXTENSIONS:
+                urls_schemes[o.scheme] = url
+    for scheme in SCHEMES:
+        # prefer https
+        if scheme in urls_schemes:
+            return urls_schemes[scheme]
     raise ValueError('No https data URL found among URLs {}'.format(urls))
 
 
-def download_entries(entries, download_dir, credentials):
+def download_file_https(url, target, username, password):
+    session = requests.Session()
+    session.auth = requests.auth.HTTPBasicAuth(username, password)
+    with session.get(url, stream=True) as response:
+        response.raise_for_status()
+        with open(target, "wb") as target_file:
+            shutil.copyfileobj(response.raw, target_file)
+    logger.info("Saved file {local_filename} ({local_filesize:d})".format(
+        local_filename=target,
+        local_filesize=os.path.getsize(target)))
+    return target
+
+
+def _hostname_path_from_url(url):
+    o = urlparse(url)
+    return o.netloc, o.path
+
+
+def download_file_ftp(url, target, username, password):
+    hostname, path = _hostname_path_from_url(url)
+    try:
+        with ftputil.FTPHost(hostname, username, password) as host:
+            host.download(path, target)
+    except ftputil.error.PermanentError:
+        raise ValueError(
+                'Unable to connect to this ftp server \'{}\'. '
+                'Consider downloading manually \'{}\'.'
+                .format(hostname, url))
+
+
+def download_entries(entries, download_dir, credentials, reuse_existing=True):
+    """Download files for all entries
+
+    Parameters
+    ----------
+    entries : list of dict
+        parsed entries
+    download_dir : str
+        path to store data
+    credentials : dict(username='', password='')
+        EarthData credentials
+    reuse_existing : bool
+        do not re-download existing files
+
+    Returns
+    -------
+    list of str : downloaded files
+    """
+    # determine data urls
     urls = []
     for e in entries:
-        url = _get_https_data_url(e['urls'])
+        url = _get_data_url(e['urls'])
         urls.append(url)
 
     local_files = []
     for url in urls:
-        local_file = eddownload.download_data(
-                url, download_dir=download_dir,
-                skip_existing=True,
-                **credentials)
+        o = urlparse(url)
+        local_file = os.path.join(download_dir, posixpath.basename(o.path))
+
+        if os.path.isfile(local_file) and reuse_existing:
+            # use existing
+            pass
+        else:
+            if o.scheme == 'ftp':
+                download_file_ftp(url, local_file, **credentials)
+            else:
+                download_file_https(url, local_file, **credentials)
+
         local_files.append(local_file)
     return local_files

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,7 @@ setup(
     modis_atm=modis_atm.scripts.modis_atm:main
     """,
     install_requires=[
-        'earthdata_download>=0.7'],
+        'earthdata_download>=0.7',
+        'ftputil'],
     dependency_links=[
         'https://github.com/DHI-GRAS/earthdata_download/archive/v0.7.zip#egg=earthdata_download-0.7'])

--- a/tests/test_params.py
+++ b/tests/test_params.py
@@ -29,6 +29,5 @@ def test_retrieve_parameters():
                 **_date_extent)
     finally:
         shutil.rmtree(tempdir)
-
     assert 'ozone' in parameters
     assert isinstance(parameters['AOT'], float)


### PR DESCRIPTION
NRT data is only available from FTP.

Possible issue: the server `ftp://ladsweb.modaps.eosdis.nasa.gov` that you also sometimes get is not really an FTP server but some virtual stuff, so login does not work.

This is heuristically mitigated by preferring HTTPS URLs when available - which they always seem to be when the ladsweb server comes up.